### PR TITLE
package: set the version in pyproject.toml, ignore VCS tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=73", "setuptools_scm[toml]>=8.1", "wheel"]
+requires = ["setuptools>=73", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9,<3.14"
 license = { text = "MIT" }
 keywords = []
-
+version = "1.4.1"
 classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = ["Click==8.1.7", "loguru==0.7.2"]
-dynamic = ["version"]
 
 
 [project.urls]
@@ -32,9 +31,6 @@ Issues = "https://github.com/AdrienCos/sapling/issues"
 
 [project.scripts]
 adriencos_sapling = "adriencos_sapling.cli:main"
-
-[tool.setuptools_scm]
-fallback_version = "0.0.1"
 
 [tool.pyright]
 include = ["src", "tests"]
@@ -98,8 +94,6 @@ known-first-party = ["adriencos_sapling"]
 extend-ignore-re = ["_commit:.*"]
 
 [tool.pdm.scripts]
-# Common configuration
-_.env_file = ".version.env"
 # Internal helper scripts
 _black_format = { cmd = [
     "black",
@@ -193,7 +187,6 @@ _dev_packages_update = { cmd = [
     # Only touch the dev packages
     "--dev",
 ], help = "Update the dev packages to their latest version" }
-_generate_version = { shell = "echo PACKAGE_VERSION=$(python -m setuptools_scm) | sed 's/+/./' > .version.env", help = "Export the package's version number to .version.env" }
 _generate_requirements = { cmd = [
     "pdm",
     "export",
@@ -221,7 +214,6 @@ _build_pex = { cmd = [
     "--pex-args",
     "--requirement=requirements.txt",
 ], help = "Build a PEX file of the package" }
-_build_docker_image = { shell = "docker build -t adriencos_sapling:dev -t adriencos_sapling:${PACKAGE_VERSION} ." }
 _build_wheel = { cmd = [
     "pdm",
     "build",
@@ -266,15 +258,11 @@ clean = { cmd = [
     "--debris",
     "all",
     "--erase",
-    ".version.env",
     "--yes",
     "--",
     ".",
 ], help = "Remove all the build artifacts, caches, and other debris" }
-docker-build = { composite = [
-    "_generate_version",
-    "_build_docker_image",
-], help = "Build a Docker image of the application" }
+docker-build = { shell = "docker build -t adriencos_sapling:dev -t adriencos_sapling:$(pdm show --version) .", help = "Build a Docker image of the application" }
 pex-build = { composite = [
     "_generate_requirements_no_hashes",
     "_build_pex",
@@ -289,7 +277,7 @@ template-update = { cmd = [
     '--skip-answered',
 ], help = "Update the project to the latest version of the template" }
 
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 dev = [
     "black==24.10.0",
     "copier==9.4.1",


### PR DESCRIPTION
## Description

Using `setuptools_scm` to get the package's version number from `git` is not really convenient when running `pdm` in a Docker build, or in a CI, where the `.git` dir and the `git` binary are not always installed.

Falling back to an explicit version number in the `pyproject.toml` file will make these actions way easier.