### PR TITLE
pdm: use [tool.pdm.dev-dependencies] to define dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,7 @@ template-update = { cmd = [
     '--skip-answered',
 ], help = "Update the project to the latest version of the template" }
 
-[dependency-groups]
+[tool.pdm.dev-dependencies]
 dev = [
     "black==24.10.0",
     "copier==9.4.1",


### PR DESCRIPTION
Renovate seems to be having problems with the `[dependency-groups]` header in `pyproject.toml` (probably because of the custom matchers added to the `renovate.json` to keep the packages and hooks in sync)